### PR TITLE
[FIX] Correct negligible difference between fmap and dwi voxel size.

### DIFF
--- a/dmri_preprocessing/workflows.py
+++ b/dmri_preprocessing/workflows.py
@@ -433,10 +433,14 @@ def prepare_eddy(data,topup_options,phase_encoding_directions,output_dir):
         diff_per = np.abs(np.mean(np.array(fmap_corr_voxels)/np.array(dwi_voxels))-1)
 
         if fmap_corr_voxels != dwi_voxels and diff_per < 1e-04:
+            # Change input mask
+            input_mean_topup_mask = eddy_inputs['in_mask']
+            eddy_inputs['in_mask'] = input_mean_topup_mask.replace("_brain.nii.gz","_brain_copygeom.nii.gz")
             copygeom = pe.Node(
                 fsl.utils.CopyGeom(
                     in_file=data['b0_mask'],
-                    dest_file=eddy_inputs['in_mask'],
+                    dest_file=input_mean_topup_mask,
+                    out_file=eddy_inputs['in_mask'],
                     output_type="NIFTI_GZ"
                 ), 
                 name='copygeom'

--- a/dmri_preprocessing/workflows.py
+++ b/dmri_preprocessing/workflows.py
@@ -435,18 +435,18 @@ def prepare_eddy(data,topup_options,phase_encoding_directions,output_dir):
         if fmap_corr_voxels != dwi_voxels and diff_per < 1e-04:
             # Change input mask
             input_mean_topup_mask = eddy_inputs['in_mask']
-            eddy_inputs['in_mask'] = input_mean_topup_mask.replace("_brain.nii.gz","_brain_copygeom.nii.gz")
             copygeom = pe.Node(
                 fsl.utils.CopyGeom(
                     in_file=data['b0_mask'],
                     dest_file=input_mean_topup_mask,
-                    out_file=eddy_inputs['in_mask'],
                     output_type="NIFTI_GZ"
                 ), 
                 name='copygeom'
             )
             copygeom.base_dir = output_dir
             copygeom.run()
+
+            eddy_inputs['in_mask'] = input_mean_topup_mask.replace("/topup/","/copygeom/")
 
         # Check if first file in acq_p file is corresponding to the same phase encoding directions as the dwi file
         if topup_options['only_fmap']:


### PR DESCRIPTION
Fixes issue #17.

Eddy fails for small difference in voxel size for brain mask and input data. This was due to brain mask was made off topup correced fieldmap which were 1.9999 in z voxel size instead of 2.0000. I fixed this by copying the header of the b0 brain mask.

